### PR TITLE
ENH Allow passing in a relative path as an argument

### DIFF
--- a/bin/doclint
+++ b/bin/doclint
@@ -103,6 +103,11 @@ if [[ -z $MODULE_DIR ]]; then
     MODULE_DIR=$ORIG_DIR
 fi
 
+# If the module directory is not an absolute path, make it one
+if [[ $MODULE_DIR != $ORIG ]] && [[ $MODULE_DIR != "/*" ]]; then
+    MODULE_DIR="${ORIG_DIR}/${MODULE_DIR}"
+fi
+
 # Get and validate the config file path
 CONFIG_FILE="${MODULE_DIR}/.doclintrc"
 if ! [[ -f $CONFIG_FILE ]]; then


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-elemental/issues/985

Allows using a non-absolute path as an argument e.g.

cd ~/Sites/somesite

`vendor/bin/doclint vendor/dnadesign/silverstripe-elemental`

Without this PR you need to call `vendor/bin/doclint $(pwd)/vendor/dnadesign/silverstripe-elemental` otherwise it'll complain that it cannot find `.doclintrc`

**github workflows haven't been added with module standardiser yet to this repo so manually tag 1.0.1 after merge and merge-up to 1**