### PR TITLE
FIX Additional check dirs are not the same

### DIFF
--- a/bin/doclint
+++ b/bin/doclint
@@ -104,7 +104,7 @@ if [[ -z $MODULE_DIR ]]; then
 fi
 
 # If the module directory is not an absolute path, make it one
-if [[ $MODULE_DIR != $ORIG ]] && [[ $MODULE_DIR != "/*" ]]; then
+if [[ $MODULE_DIR != $ORIG_DIR ]] && [[ "$MODULE_DIR/" != $ORIG_DIR ]] && [[ $MODULE_DIR != "/*" ]]; then
     MODULE_DIR="${ORIG_DIR}/${MODULE_DIR}"
 fi
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-elemental/issues/985

Fixes `No '.doclintrc' file found at /home/runner/work/silverstripe-userforms/silverstripe-userforms//home/runner/work/silverstripe-userforms/silverstripe-userforms` https://github.com/silverstripe/silverstripe-userforms/actions/runs/8610141856/job/23595207034?pr=1278