### PR TITLE
MNT Add ci.yml so merge-up and patch tagging works as expected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  ci:
+    name: CI
+    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1
+    with:
+      # There's no actual PHP or JS, despite having phpcs.xml and package.json files.
+      phplinting: false
+      js: false


### PR DESCRIPTION
Fixes https://github.com/silverstripe/documentation-lint/actions/runs/10082933001/job/27878322958

> Could not workflow file for branch 1 - tried action-ci-self.yml action-ci.yml ci.yml

## Issue
- https://github.com/silverstripe/.github/issues/287