### PR TITLE
MNT Replace CI with patch release dispatcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,41 @@ name: CI
 
 on:
   push:
-  pull_request:
   workflow_dispatch:
+
+permissions: {}
 
 jobs:
   ci:
-    name: CI
-    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1
-    with:
-      # There's no actual PHP or JS, despite having phpcs.xml and package.json files.
-      phplinting: false
-      js: false
+    # This repo has no tests and nothing to lint, so we can't use regular CI.
+    # Instead, just directly dispatch tag release on push, and let that figure it out.
+    name: Dispatch tag patch release
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'silverstripe'
+    permissions:
+      actions: write
+    env:
+      GITHUB_REPOSITORY: ${{ github.repository }}
+      BRANCH: ${{ github.ref_name }}
+    steps:
+
+      - name: Dispatch tag patch release
+        shell: bash
+        id: dispatch-tag-patch-release
+        run: |
+          LATEST_LOCAL_SHA=$(git rev-parse HEAD)
+          echo "LATEST_LOCAL_SHA is $LATEST_LOCAL_SHA"
+          # https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event
+          RESP_CODE=$(curl -w %{http_code} -s -L -o __response.json \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/tag-patch-release.yml/dispatches \
+            -d "{\"ref\":\"$BRANCH\",\"inputs\":{\"latest_local_sha\":\"$LATEST_LOCAL_SHA\"}}"
+          )
+          if [[ $RESP_CODE != "204" ]]; then
+            echo "Failed to dispatch workflow - HTTP response code was $RESP_CODE"
+            cat __response.json
+            exit 1
+          fi


### PR DESCRIPTION
Fixes https://github.com/silverstripe/documentation-lint/actions/runs/10278318056
> Error when evaluating 'strategy' for job 'tests'. silverstripe/gha-ci/.github/workflows/ci.yml@v1 (Line: 131, Col: 15): Matrix must define at least one vector

Turns out when there's nothing to test or lint, the matrix is empty and the `tests` job doesn't run at all. And then anything that `needs` that job is marked as failed.

Replacing CI here since we have no tests or linting to do - instead we'll just dispatch patch tagging on push.


## Issue
- https://github.com/silverstripe/.github/issues/298