### PR TITLE
FIX Don't try to use `git` when we haven't checked out the code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,13 @@ jobs:
     env:
       GITHUB_REPOSITORY: ${{ github.repository }}
       BRANCH: ${{ github.ref_name }}
+      LATEST_LOCAL_SHA: ${{ github.sha }}
     steps:
 
       - name: Dispatch tag patch release
         shell: bash
         id: dispatch-tag-patch-release
         run: |
-          LATEST_LOCAL_SHA=$(git rev-parse HEAD)
           echo "LATEST_LOCAL_SHA is $LATEST_LOCAL_SHA"
           # https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event
           RESP_CODE=$(curl -w %{http_code} -s -L -o __response.json \


### PR DESCRIPTION
Oops! We can't use `git` because we didn't check out the code!
GitHub already knows the sha though, it's in `github.sha` (see [context docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context))

Fixes https://github.com/silverstripe/documentation-lint/actions/runs/10570860007/job/29286008106
> fatal: not a git repository (or any of the parent directories): .git

## Issue
- https://github.com/silverstripe/.github/issues/298