### PR TITLE
FIX Allow references to `silverstripe/htmleditor-tinymce`

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -105,6 +105,7 @@ enhanced-proper-names:
     - 'silverstripe-' # e.g. "silverstripe-vendormodule"
     - '@silverstripe.org'
     - 'TinyMCE'
+    - 'htmleditor-tinymce' # specifically silverstripe/htmleditor-tinymce
     - 'UI'
     - 'URL'
     - 'YAML'


### PR DESCRIPTION
Needed to fix https://github.com/silverstripe/developer-docs/actions/runs/13847778124/job/38749560179?pr=691
> enhanced-proper-names Proper names should have the correct capitalization [Expected: TinyMCE; Actual: tinymce]

## Issue
- https://github.com/silverstripe/silverstripe-htmleditor-tinymce/issues/2