### PR TITLE
FIX Allow months with capital letters in headings

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -142,6 +142,19 @@ title-case-style:
     - 'Transifex'
     - 'URLs'
     - 'WebP'
+    # months should have capital letters
+    - 'January'
+    - 'February'
+    - 'March'
+    - 'April'
+    - 'May'
+    - 'June'
+    - 'July'
+    - 'August'
+    - 'September'
+    - 'October'
+    - 'November'
+    - 'December'
 
 # MD033: Allow specific HTML tags
 no-inline-html:


### PR DESCRIPTION
Fixes https://github.com/silverstripe/developer-docs/actions/runs/14369091561/job/40288516924

```text
 08_Changelogs/5.4.0.md:118 title-case-style Letter case style [Expected: 'Released in january 2025'; Actual: 'Released in January 2025']
```

## Issue
- https://github.com/silverstripe/.github/issues/389