### PR TITLE
ENH Disable MD037 no-space-in-emphasis

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -155,3 +155,9 @@ no-inline-html:
     - 'dl'
     - 'dd'
     - 'dt'
+
+# MD037 - Spaces inside emphasis markers
+# There is a changelog commit containing "a _config.php file or _config directory"
+# markdownlint will complain about "r _"
+# There are no optional available to disable just this instance, do we need to disable the entire rule
+no-space-in-emphasis: false


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/410

Fixes https://github.com/silverstripe/developer-docs/actions/runs/15173188067/job/42667951000#step:8:41
`08_Changelogs/rc/6.0.0-rc1.md:3041:160 MD037/no-space-in-emphasis Spaces inside emphasis markers [Context: "r _"]`

Create 1.1 branch and release 1.1.0 after merge